### PR TITLE
Improve performance and add Save As option

### DIFF
--- a/cdr_parser.py
+++ b/cdr_parser.py
@@ -38,14 +38,20 @@ class CDRParser:
             file_size = os.path.getsize(filepath)
             self.logger.info(f"Processing file {filepath} of size {file_size} bytes")
 
-            # For files larger than 1MB, use enhanced BCD parsing directly
-            if file_size > 1024 * 1024:  # 1MB
-                self.logger.info("Large file detected - using enhanced BCD parsing")
+            # Very large files are parsed in chunks to avoid memory issues
+            if file_size > 10 * 1024 * 1024:  # >10MB
+                self.logger.info("Large file detected - using chunked parser")
+                return self.parse_large_file(filepath)
+
+            # Medium sized files use the raw binary parser for speed
+            if file_size > 1024 * 1024:  # >1MB
+                self.logger.info("Medium file detected - using enhanced BCD parsing")
                 return self.parse_raw_binary_file(filepath)
-            else:
-                with open(filepath, "rb") as f:
-                    data = f.read()
-                return self.parse_binary_data(data)
+
+            # Small files are loaded entirely in memory
+            with open(filepath, "rb") as f:
+                data = f.read()
+            return self.parse_binary_data(data)
 
         except Exception as e:
             self.logger.error(f"Error reading file {filepath}: {str(e)}")

--- a/templates/results.html
+++ b/templates/results.html
@@ -57,6 +57,9 @@
                     <a href="{{ url_for('export_data', file_id=cdr_file.id, format='csv') }}" class="btn btn-outline-primary btn-sm">
                         <i class="fas fa-download me-1"></i>Export CSV
                     </a>
+                    <a href="{{ url_for('save_as', file_id=cdr_file.id) }}" class="btn btn-outline-info btn-sm">
+                        <i class="fas fa-save me-1"></i>Save As
+                    </a>
                 </div>
                 {% endif %}
             </div>

--- a/templates/save_as.html
+++ b/templates/save_as.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}Save As - {{ cdr_file.original_filename }}{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title mb-0">
+                    <i class="fas fa-save me-2"></i>Save As New File
+                </h5>
+            </div>
+            <div class="card-body">
+                <form method="POST">
+                    <div class="mb-3">
+                        <label for="filename" class="form-label">New File Name</label>
+                        <input type="text" class="form-control" id="filename" name="filename" required
+                               placeholder="example.cdr">
+                        <div class="form-text">
+                            Allowed types: {{ ', '.join(ALLOWED_EXTENSIONS) }}
+                        </div>
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <a href="{{ url_for('view_results', file_id=cdr_file.id) }}" class="btn btn-outline-secondary">
+                            <i class="fas fa-arrow-left me-2"></i>Cancel
+                        </a>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save me-2"></i>Save
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- optimize parser for large CDR files
- implement Save As functionality for parsed files
- add Save As form and button

## Testing
- `python -m py_compile app.py routes.py cdr_parser.py models.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_687e3a917020832fbc5a296e1a0e3ad5