### PR TITLE
Improve performance and add Save As option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# ASNCdrParser
+# SENORA ASN
+
+SENORA ASN is a web-based tool for parsing telecom Call Detail Records stored in binary ASN.1 format. It allows uploading large CDR files, viewing parsed records, and exporting data. Originally created by Rosane, this project now includes performance improvements and a convenient **Save As** feature to duplicate processed files.
+
+## Features
+- Efficient parsing for large and small files
+- Database-backed storage of parsed records
+- Searchable, sortable tables
+- Export to CSV or JSON
+- "Save As" to create new files from existing records
+- Incremental parsing in batches of 1000 records
+- Option to split a selection of records into a new file
+
+## Running
+Install dependencies with `pip install -r requirements.txt` or via `poetry install`, then start the app with:
+
+```bash
+python main.py
+```
+
+The application will be available at `http://localhost:5000`.

--- a/cdr_parser.py
+++ b/cdr_parser.py
@@ -11,7 +11,7 @@ from pyasn1 import error
 
 
 class CDRParser:
-    """ASN.1 CDR Parser for telecom Call Detail Records"""
+    """SENORA ASN parser for telecom Call Detail Records"""
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)
@@ -38,14 +38,20 @@ class CDRParser:
             file_size = os.path.getsize(filepath)
             self.logger.info(f"Processing file {filepath} of size {file_size} bytes")
 
-            # For files larger than 1MB, use enhanced BCD parsing directly
-            if file_size > 1024 * 1024:  # 1MB
-                self.logger.info("Large file detected - using enhanced BCD parsing")
+            # Very large files are parsed in chunks to avoid memory issues
+            if file_size > 10 * 1024 * 1024:  # >10MB
+                self.logger.info("Large file detected - using chunked parser")
+                return self.parse_large_file(filepath)
+
+            # Medium sized files use the raw binary parser for speed
+            if file_size > 1024 * 1024:  # >1MB
+                self.logger.info("Medium file detected - using enhanced BCD parsing")
                 return self.parse_raw_binary_file(filepath)
-            else:
-                with open(filepath, "rb") as f:
-                    data = f.read()
-                return self.parse_binary_data(data)
+
+            # Small files are loaded entirely in memory
+            with open(filepath, "rb") as f:
+                data = f.read()
+            return self.parse_binary_data(data)
 
         except Exception as e:
             self.logger.error(f"Error reading file {filepath}: {str(e)}")
@@ -54,6 +60,42 @@ class CDRParser:
                 return self.parse_raw_binary_file(filepath)
             except Exception:
                 raise Exception(f"Failed to read file: {str(e)}")
+
+    def parse_file_chunk(self, filepath, start_record=0, max_records=1000):
+        """Parse a portion of a CDR file starting at ``start_record``.
+
+        Returns a tuple ``(records, reached_end)`` where ``records`` is a list
+        of parsed records and ``reached_end`` indicates if the end of the file
+        was reached during parsing.
+        """
+        records = []
+        chunk_size = 10 * 1024 * 1024  # 10MB
+        record_index = 0
+        reached_end = False
+
+        try:
+            with open(filepath, "rb") as f:
+                while len(records) < max_records:
+                    chunk = f.read(chunk_size)
+                    if not chunk:
+                        reached_end = True
+                        break
+
+                    chunk_records = self.parse_binary_data_chunk(chunk, record_index)
+                    for r in chunk_records:
+                        if record_index >= start_record and len(records) < max_records:
+                            records.append(r)
+                        record_index += 1
+                        if len(records) >= max_records:
+                            break
+
+                    if len(records) >= max_records:
+                        break
+
+        except Exception as e:
+            self.logger.error(f"Error processing file chunk: {str(e)}")
+
+        return records, reached_end
 
     def parse_binary_data(self, data):
         """Parse binary ASN.1 data and extract CDR records"""

--- a/replit.md
+++ b/replit.md
@@ -1,4 +1,4 @@
-# ASN.1 CDR Parser
+# SENORA ASN
 
 ## Overview
 

--- a/routes.py
+++ b/routes.py
@@ -16,6 +16,7 @@ from werkzeug.utils import secure_filename
 from app import app, db
 from models import CDRFile, CDRRecord
 from cdr_parser import CDRParser
+import shutil
 import tempfile
 import csv
 import io
@@ -499,3 +500,131 @@ def delete_file(file_id):
         flash(f"Error deleting file: {str(e)}", "error")
 
     return redirect(url_for("index"))
+
+
+@app.route("/save_as/<int:file_id>", methods=["GET", "POST"])
+def save_as(file_id):
+    """Save the parsed records to a new file and database entry."""
+    cdr_file = CDRFile.query.get_or_404(file_id)
+
+    if request.method == "POST":
+        new_name = request.form.get("filename", "").strip()
+        if not new_name:
+            flash("Filename is required", "error")
+            return redirect(request.url)
+
+        if not allowed_file(new_name):
+            flash(
+                "Invalid file type. Allowed types: " + ", ".join(ALLOWED_EXTENSIONS),
+                "error",
+            )
+            return redirect(request.url)
+
+        try:
+            start_idx = int(request.form.get("start_index", 0))
+        except ValueError:
+            start_idx = 0
+        try:
+            end_idx = int(request.form.get("end_index", cdr_file.records_count - 1))
+        except ValueError:
+            end_idx = cdr_file.records_count - 1
+
+        if start_idx < 0:
+            start_idx = 0
+        if end_idx >= cdr_file.records_count:
+            end_idx = cdr_file.records_count - 1
+        if end_idx < start_idx:
+            flash("Invalid record range", "error")
+            return redirect(request.url)
+
+        new_filename = secure_filename(new_name)
+        new_path = os.path.join(app.config["UPLOAD_FOLDER"], new_filename)
+        if os.path.exists(new_path):
+            flash("File already exists", "error")
+            return redirect(request.url)
+
+        # Copy the original file first
+        original_path = os.path.join(app.config["UPLOAD_FOLDER"], cdr_file.filename)
+        shutil.copy2(original_path, new_path)
+
+        parser = CDRParser()
+        selected_records = (
+            CDRRecord.query.filter_by(file_id=cdr_file.id)
+            .filter(CDRRecord.record_index >= start_idx)
+            .filter(CDRRecord.record_index <= end_idx)
+            .order_by(CDRRecord.record_index)
+            .all()
+        )
+        records_data = []
+        for r in selected_records:
+            data = r.get_raw_data()
+            if "calling_number" not in data:
+                data["calling_number"] = r.calling_number
+            records_data.append(data)
+
+        parser.save_records_to_file(new_path, records_data)
+        file_size = os.path.getsize(new_path)
+
+        new_file = CDRFile(
+            filename=new_filename,
+            original_filename=new_filename,
+            file_size=file_size,
+            parse_status="success",
+            records_count=len(records_data),
+        )
+        db.session.add(new_file)
+        db.session.commit()
+
+        for i, r in enumerate(selected_records):
+            new_record = CDRRecord(
+                file_id=new_file.id,
+                record_index=i,
+                record_type=r.record_type,
+                calling_number=r.calling_number,
+                called_number=r.called_number,
+                call_duration=r.call_duration,
+                start_time=r.start_time,
+                end_time=r.end_time,
+            )
+            new_record.set_raw_data(r.get_raw_data())
+            db.session.add(new_record)
+
+        db.session.commit()
+        flash(f"File saved as {new_filename}", "success")
+        return redirect(url_for("view_results", file_id=new_file.id))
+
+    return render_template("save_as.html", cdr_file=cdr_file, ALLOWED_EXTENSIONS=ALLOWED_EXTENSIONS)
+
+
+@app.route("/parse_next/<int:file_id>", methods=["POST"])
+def parse_next(file_id):
+    """Parse the next 1000 records from the CDR file."""
+    cdr_file = CDRFile.query.get_or_404(file_id)
+    start_index = CDRRecord.query.filter_by(file_id=file_id).count()
+    filepath = os.path.join(app.config["UPLOAD_FOLDER"], cdr_file.filename)
+
+    parser = CDRParser()
+    records, reached_end = parser.parse_file_chunk(filepath, start_record=start_index, max_records=1000)
+
+    if not records:
+        flash("No more records found", "info")
+        return redirect(url_for("view_results", file_id=file_id))
+
+    for i, record in enumerate(records):
+        cdr_record = CDRRecord(
+            file_id=file_id,
+            record_index=start_index + i,
+            record_type=record.get("record_type", "unknown"),
+            calling_number=record.get("calling_number"),
+            called_number=record.get("called_number"),
+            call_duration=record.get("call_duration"),
+            start_time=record.get("start_time"),
+            end_time=record.get("end_time"),
+        )
+        cdr_record.set_raw_data(record)
+        db.session.add(cdr_record)
+
+    cdr_file.records_count = start_index + len(records)
+    db.session.commit()
+    flash(f"Parsed {len(records)} additional records", "success")
+    return redirect(url_for("view_results", file_id=file_id))

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,4 +1,4 @@
-/* Custom CSS for ASN.1 CDR Parser */
+/* Custom CSS for SENORA ASN */
 
 /* Use Bootstrap dark theme variables */
 :root {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,4 +1,4 @@
-// Main JavaScript file for ASN.1 CDR Parser
+// Main JavaScript file for SENORA ASN
 
 $(document).ready(function() {
     // Initialize DataTables if present

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}ASN.1 CDR Parser{% endblock %}</title>
+    <title>{% block title %}SENORA ASN{% endblock %}</title>
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.replit.com/agent/bootstrap-agent-dark-theme.min.css" rel="stylesheet">
@@ -23,7 +23,7 @@
         <div class="container">
             <a class="navbar-brand" href="{{ url_for('index') }}">
                 <i class="fas fa-file-code me-2"></i>
-                ASN.1 CDR Parser
+                SENORA ASN
             </a>
             
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
@@ -68,7 +68,7 @@
     <!-- Footer -->
     <footer class="bg-dark text-light py-4 mt-5">
         <div class="container text-center">
-            <p>&copy; 2025 ASN.1 CDR Parser. Built with Flask and Bootstrap.</p>
+            <p>&copy; 2025 SENORA ASN. Created by Rosane.</p>
         </div>
     </footer>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}Home - ASN.1 CDR Parser{% endblock %}
+{% block title %}Home - SENORA ASN{% endblock %}
 
 {% block content %}
 <div class="row">
     <div class="col-12">
         <div class="jumbotron bg-secondary p-5 rounded-3 mb-4">
-            <h1 class="display-4"><i class="fas fa-file-code me-3"></i>ASN.1 CDR Parser</h1>
+            <h1 class="display-4"><i class="fas fa-file-code me-3"></i>SENORA ASN</h1>
             <p class="lead">Upload and parse telecom Call Detail Records (CDR) from binary ASN.1 files. Extract call information, analyze usage patterns, and export data in multiple formats.</p>
             <hr class="my-4">
             <p>Supports common telecom CDR formats including 3GPP standards. Parse voice calls, SMS, and data session records with detailed field extraction.</p>

--- a/templates/results.html
+++ b/templates/results.html
@@ -57,6 +57,14 @@
                     <a href="{{ url_for('export_data', file_id=cdr_file.id, format='csv') }}" class="btn btn-outline-primary btn-sm">
                         <i class="fas fa-download me-1"></i>Export CSV
                     </a>
+                    <a href="{{ url_for('save_as', file_id=cdr_file.id) }}" class="btn btn-outline-info btn-sm">
+                        <i class="fas fa-save me-1"></i>Save As
+                    </a>
+                    <form action="{{ url_for('parse_next', file_id=cdr_file.id) }}" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-outline-secondary btn-sm">
+                            <i class="fas fa-forward me-1"></i>Parse Next 1000
+                        </button>
+                    </form>
                 </div>
                 {% endif %}
             </div>

--- a/templates/save_as.html
+++ b/templates/save_as.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}Save As - {{ cdr_file.original_filename }}{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title mb-0">
+                    <i class="fas fa-save me-2"></i>Save As New File
+                </h5>
+            </div>
+            <div class="card-body">
+                <form method="POST">
+                    <div class="mb-3">
+                        <label for="filename" class="form-label">New File Name</label>
+                        <input type="text" class="form-control" id="filename" name="filename" required
+                               placeholder="example.cdr">
+                        <div class="form-text">
+                            Allowed types: {{ ', '.join(ALLOWED_EXTENSIONS) }}
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="start_index" class="form-label">Start Record</label>
+                        <input type="number" class="form-control" id="start_index" name="start_index" value="0" min="0">
+                    </div>
+                    <div class="mb-3">
+                        <label for="end_index" class="form-label">End Record</label>
+                        <input type="number" class="form-control" id="end_index" name="end_index"
+                               value="{{ cdr_file.records_count - 1 }}" min="0">
+                    </div>
+                    <div class="d-flex justify-content-between">
+                        <a href="{{ url_for('view_results', file_id=cdr_file.id) }}" class="btn btn-outline-secondary">
+                            <i class="fas fa-arrow-left me-2"></i>Cancel
+                        </a>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save me-2"></i>Save
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Upload CDR File - ASN.1 CDR Parser{% endblock %}
+{% block title %}Upload CDR File - SENORA ASN{% endblock %}
 
 {% block content %}
 <div class="row justify-content-center">


### PR DESCRIPTION
## Summary
- optimize parser for large CDR files
- implement Save As functionality for parsed files
- add Save As form and button
- rebrand UI as **SENORA ASN**
- parse 1000 records at a time and allow parsing the next chunk
- allow splitting records when saving as new file

## Testing
- `python -m py_compile app.py routes.py cdr_parser.py models.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_687e3a917020832fbc5a296e1a0e3ad5