### PR TITLE
Fix XML decoder loading

### DIFF
--- a/cdr_parser.py
+++ b/cdr_parser.py
@@ -61,9 +61,6 @@ class CDRParser:
         except Exception as exc:  # pragma: no cover - best effort
             self.logger.error(f"Failed to load XML spec {xml_path}: {exc}")
             raise
-                self.spec = asn1tools.compile_files(spec_path, "ber")
-            except Exception as exc:  # pragma: no cover - best effort
-                self.logger.error(f"Failed to load ASN.1 spec {spec_path}: {exc}")
 
     def parse_timestamp_from_filename(self, filename):
         """Extract a timestamp from a filename if present.


### PR DESCRIPTION
## Summary
- fix indentation error in `_load_xml_spec`
- ensure XML spec loading doesn't crash

## Testing
- `python -m py_compile app.py routes.py cdr_parser.py models.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6888a44c7ca8832fa46ab4c84ce48ba9