### PR TITLE
Add API for ASN.1 CDR decoding with XML spec

### DIFF
--- a/cdr_parser.py
+++ b/cdr_parser.py
@@ -61,9 +61,6 @@ class CDRParser:
         except Exception as exc:  # pragma: no cover - best effort
             self.logger.error(f"Failed to load XML spec {xml_path}: {exc}")
             raise
-                self.spec = asn1tools.compile_files(spec_path, "ber")
-            except Exception as exc:  # pragma: no cover - best effort
-                self.logger.error(f"Failed to load ASN.1 spec {spec_path}: {exc}")
 
     def parse_timestamp_from_filename(self, filename):
         """Extract a timestamp from a filename if present.

--- a/decoder_util.py
+++ b/decoder_util.py
@@ -1,0 +1,79 @@
+import logging
+from typing import List, Dict, Any
+import xmltodict
+import asn1tools
+
+
+def decode_cdr(cdr_bytes: bytes, xml_spec: str) -> List[Dict[str, Any]]:
+    """Decode ASN.1 CDR bytes using the provided XML spec.
+
+    Parameters
+    ----------
+    cdr_bytes: bytes
+        Raw bytes of the CDR file.
+    xml_spec: str
+        XML string describing the decoder fields.
+
+    Returns
+    -------
+    list of dict
+        Decoded records with mapped field names.
+    """
+    logger = logging.getLogger(__name__)
+    spec_dict = xmltodict.parse(xml_spec)
+    field_entries = spec_dict.get("decoder", {}).get("field", [])
+    if isinstance(field_entries, dict):
+        field_entries = [field_entries]
+
+    field_names = []
+    for entry in field_entries:
+        name = entry.get("name")
+        if name:
+            field_names.append(name)
+        else:
+            logger.warning("Skipped field with no name in XML spec")
+    if not field_names:
+        raise ValueError("No fields defined in XML spec")
+
+    asn_lines = ["DECODER DEFINITIONS ::= BEGIN", "Record ::= SEQUENCE {"]
+    for idx, fname in enumerate(field_names):
+        comma = "," if idx < len(field_names) - 1 else ""
+        asn_lines.append(f"    {fname} IA5String OPTIONAL{comma}")
+    asn_lines.append("}")
+    asn_lines.append("END")
+    asn_text = "\n".join(asn_lines)
+
+    compiled = asn1tools.compile_string(asn_text, "ber")
+
+    records: List[Dict[str, Any]] = []
+    offset = 0
+    data = cdr_bytes
+    while offset < len(data):
+        try:
+            decoded, rest = compiled.decode("Record", data[offset:], check_constraints=False)
+            offset = len(data) - len(rest)
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.warning("Decode error at offset %d: %s", offset, exc)
+            break
+        rec_dict: Dict[str, Any] = {}
+        for k, v in decoded.items():
+            value = str(v)
+            lk = k.lower()
+            if "calling" in lk and "number" in lk:
+                rec_dict["calling_number"] = value
+            elif "called" in lk and "number" in lk:
+                rec_dict["called_number"] = value
+            elif "duration" in lk:
+                try:
+                    rec_dict["duration"] = int(value)
+                except ValueError:
+                    rec_dict["duration"] = value
+            elif "start" in lk and "time" in lk:
+                rec_dict["start_time"] = value
+            elif "end" in lk and "time" in lk:
+                rec_dict["end_time"] = value
+            else:
+                logger.info("Unknown field %s skipped", k)
+                rec_dict[k] = value
+        records.append(rec_dict)
+    return records

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "psycopg2-binary>=2.9.10",
     "pyasn1>=0.6.1",
     "asn1tools>=0.167.0",
+    "xmltodict>=0.13.0",
     "sqlalchemy>=2.0.41",
     "werkzeug>=3.1.3",
 ]

--- a/routes.py
+++ b/routes.py
@@ -15,6 +15,7 @@ from werkzeug.utils import secure_filename
 from app import app, db
 from models import CDRFile, CDRRecord
 from cdr_parser import CDRParser
+from decoder_util import decode_cdr
 import shutil
 import csv
 import io
@@ -31,6 +32,24 @@ def index():
     # Get recent files
     recent_files = CDRFile.query.order_by(CDRFile.upload_time.desc()).limit(10).all()
     return render_template("index.html", recent_files=recent_files)
+
+
+@app.route("/upload-cdr", methods=["POST"])
+def upload_cdr_api():
+    """API endpoint to decode a CDR file using an XML specification."""
+    if "cdr_file" not in request.files or "xml_spec" not in request.files:
+        return jsonify({"error": "cdr_file and xml_spec are required"}), 400
+
+    cdr_bytes = request.files["cdr_file"].read()
+    xml_content = request.files["xml_spec"].read().decode("utf-8", errors="ignore")
+
+    try:
+        records = decode_cdr(cdr_bytes, xml_content)
+    except Exception as exc:
+        logging.error("Failed to decode CDR: %s", exc)
+        return jsonify({"error": str(exc)}), 400
+
+    return jsonify({"records": records})
 
 
 @app.route("/upload", methods=["GET", "POST"])


### PR DESCRIPTION
## Summary
- add new `decode_cdr` utility to dynamically decode ASN.1 data using an XML spec
- expose `/upload-cdr` API endpoint to upload a CDR file and XML spec
- include new dependency `xmltodict`
- fix indentation issue in `cdr_parser`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888a5408704832f9eab7c7c6e4c170e