### PR TITLE
Add dynamic XML decoder and new API endpoint

### DIFF
--- a/dynamic_decoder.py
+++ b/dynamic_decoder.py
@@ -1,0 +1,58 @@
+import logging
+from typing import List, Dict, Any, Tuple
+
+import xmltodict
+from pyasn1.type import univ, char, namedtype
+from pyasn1.codec.ber import decoder as ber_decoder
+
+
+def parse_xml_spec(xml_content: str) -> Tuple[univ.Sequence, List[str]]:
+    """Parse a simple decoder XML and return a pyasn1 schema."""
+    logger = logging.getLogger(__name__)
+    if xml_content.strip().startswith('<'):
+        xml_data = xml_content
+    else:
+        with open(xml_content, 'r', encoding='utf-8') as fh:
+            xml_data = fh.read()
+
+    spec = xmltodict.parse(xml_data)
+    field_entries = spec.get('decoder', {}).get('field', [])
+    if isinstance(field_entries, dict):
+        field_entries = [field_entries]
+
+    named_types = []
+    field_names = []
+    for entry in field_entries:
+        name = entry.get('@name') or entry.get('name')
+        if not name:
+            logger.debug('Skipped field with no name in XML spec')
+            continue
+        field_names.append(name)
+        named_types.append(namedtype.OptionalNamedType(name, char.VisibleString()))
+
+    schema = univ.Sequence()
+    schema.componentType = namedtype.NamedTypes(*named_types)
+    return schema, field_names
+
+
+def decode_cdr(cdr_bytes: bytes, xml_spec: str) -> List[Dict[str, Any]]:
+    """Decode ASN.1 CDR bytes using the provided XML spec."""
+    schema, field_names = parse_xml_spec(xml_spec)
+    offset = 0
+    records: List[Dict[str, Any]] = []
+    while offset < len(cdr_bytes):
+        try:
+            decoded, rest = ber_decoder.decode(cdr_bytes[offset:], asn1Spec=schema)
+            offset = len(cdr_bytes) - len(rest)
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.debug("Decode error at offset %d: %s", offset, exc)
+            break
+        rec_dict: Dict[str, Any] = {}
+        for name in field_names:
+            value = decoded.getComponentByName(name)
+            if value is not None:
+                rec_dict[name] = str(value)
+            else:
+                logging.debug("Missing optional field %s", name)
+        records.append(rec_dict)
+    return records

--- a/routes.py
+++ b/routes.py
@@ -16,6 +16,7 @@ from app import app, db
 from models import CDRFile, CDRRecord
 from cdr_parser import CDRParser
 from decoder_util import decode_cdr
+from dynamic_decoder import decode_cdr as decode_cdr_dynamic
 import shutil
 import csv
 import io
@@ -46,6 +47,24 @@ def upload_cdr_api():
     try:
         records = decode_cdr(cdr_bytes, xml_content)
     except Exception as exc:
+        logging.error("Failed to decode CDR: %s", exc)
+        return jsonify({"error": str(exc)}), 400
+
+    return jsonify({"records": records})
+
+
+@app.route("/decode-cdr", methods=["POST"])
+def decode_cdr_endpoint():
+    """Decode a CDR file using an uploaded decoder XML and return JSON."""
+    if "cdr_file" not in request.files or "xml_spec" not in request.files:
+        return jsonify({"error": "cdr_file and xml_spec are required"}), 400
+
+    cdr_bytes = request.files["cdr_file"].read()
+    xml_content = request.files["xml_spec"].read().decode("utf-8", errors="ignore")
+
+    try:
+        records = decode_cdr_dynamic(cdr_bytes, xml_content)
+    except Exception as exc:  # pragma: no cover - best effort
         logging.error("Failed to decode CDR: %s", exc)
         return jsonify({"error": str(exc)}), 400
 


### PR DESCRIPTION
## Summary
- add `dynamic_decoder.py` with helper functions to build a pyasn1 schema from XML specs and decode CDR bytes
- create `/decode-cdr` API endpoint that accepts a CDR file and XML specification and returns JSON

## Testing
- `python -m py_compile dynamic_decoder.py routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6888ace259f4832f92e866b3397151c7